### PR TITLE
`node:10` --> `node:lts-alpine`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ###############################################################################
 # build environment                                                           #
 ###############################################################################
-FROM node:10 as build
+FROM node:lts-alpine as build
 
 WORKDIR /app
 COPY client/package*.json ./
-RUN npm install
+RUN npm install --only=prod
 
 COPY client/ ./
 RUN npm run build
@@ -14,7 +14,7 @@ RUN ls
 ###############################################################################
 # deployable environment                                                      #
 ###############################################################################
-FROM node:10 as deployable
+FROM node:lts-alpine as deployable
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -24,7 +24,7 @@ WORKDIR /usr/src/app
 COPY server/package*.json ./
 
 
-RUN npm install
+RUN npm install --only=prod
 
 # Bundle app source
 COPY server/ ./


### PR DESCRIPTION
- 1280 --> 0 vulnerabilities
- 940MB --> 192MB

Also added `--only=prod` for the `npm install` command.

In sync with https://github.com/humanitec-tutorials/sample-service/pull/2 too.